### PR TITLE
Keep the complete history of leave a team and join a team

### DIFF
--- a/www/administrator/components/com_volunteers/models/department.php
+++ b/www/administrator/components/com_volunteers/models/department.php
@@ -222,15 +222,15 @@ class VolunteersModelDepartment extends JModelAdmin
 			switch ($item->position)
 			{
 				case 9:
-					$leaders[$item->volunteer_name] = $item;
+					$leaders[$item->volunteer_name . $item->date_ended] = $item;
 					break;
 
 				case 10:
-					$assistants[$item->volunteer_name] = $item;
+					$assistants[$item->volunteer_name . $item->date_ended] = $item;
 					break;
 
 				default:
-					$volunteers[$item->volunteer_name] = $item;
+					$volunteers[$item->volunteer_name . $item->date_ended] = $item;
 					break;
 			}
 		}

--- a/www/administrator/components/com_volunteers/models/team.php
+++ b/www/administrator/components/com_volunteers/models/team.php
@@ -298,15 +298,15 @@ class VolunteersModelTeam extends JModelAdmin
 			switch ($item->position)
 			{
 				case 2:
-					$leaders[$item->volunteer_name] = $item;
+					$leaders[$item->volunteer_name . $item->date_ended] = $item;
 					break;
 
 				case 7:
-					$assistants[$item->volunteer_name] = $item;
+					$assistants[$item->volunteer_name . $item->date_ended] = $item;
 					break;
 
 				default:
-					$volunteers[$item->volunteer_name] = $item;
+					$volunteers[$item->volunteer_name . $item->date_ended] = $item;
 					break;
 			}
 		}


### PR DESCRIPTION
#### Example

Listed as active member of the CMS Maintainers: https://volunteers.joomla.org/joomlers/248-tobias-zulauf

Not listed as active member of the CMS Maintainers: https://volunteers.joomla.org/teams/cms-maintenance-team#members

This should fix that problem by extending the array identifiere after https://github.com/joomla/volunteers.joomla.org/commit/c5b90a425f7f3fecff5e763cd7be2bc8e863a56c :smile: 
