### PR TITLE
Use Bootstrap tab script

### DIFF
--- a/www/components/com_volunteers/views/department/tmpl/default.php
+++ b/www/components/com_volunteers/views/department/tmpl/default.php
@@ -7,10 +7,6 @@
 
 // No direct access.
 defined('_JEXEC') or die;
-
-JHtml::_('bootstrap.framework');
-$this->document->addScriptDeclaration("jQuery(function(\$){\$('#tab-container a').click(function(e){e.preventDefault();\$(this).tab('show');});});");
-
 ?>
 <div class="row-fluid">
 	<div class="filter-bar">
@@ -320,15 +316,6 @@ $this->document->addScriptDeclaration("jQuery(function(\$){\$('#tab-container a'
 	if (url.match('#')) {
 		jQuery('.nav-tabs a[href="#' + url.split('#')[1] + '"]').tab('show');
 	}
-
-	// With HTML5 history API, we can easily prevent scrolling!
-	jQuery('.nav-tabs a').on('shown.bs.tab', function (e) {
-		if (history.pushState) {
-			history.pushState(null, null, e.target.hash);
-		} else {
-			window.location.hash = e.target.hash; //Polyfill for old browsers
-		}
-	});
 
 	jQuery('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
 		var target = this.href.split('#');

--- a/www/components/com_volunteers/views/department/tmpl/default.php
+++ b/www/components/com_volunteers/views/department/tmpl/default.php
@@ -9,7 +9,7 @@
 defined('_JEXEC') or die;
 
 JHtml::_('bootstrap.framework');
-$this->document->addScriptDeclaration("jQuery(function($){$('#tab-container a').click(function(e){e.preventDefault();$(this).tab('show');});});");
+$this->document->addScriptDeclaration("jQuery(function(\$){\$('#tab-container a').click(function(e){e.preventDefault();\$(this).tab('show');});});");
 
 ?>
 <div class="row-fluid">

--- a/www/components/com_volunteers/views/department/tmpl/default.php
+++ b/www/components/com_volunteers/views/department/tmpl/default.php
@@ -7,6 +7,10 @@
 
 // No direct access.
 defined('_JEXEC') or die;
+
+JHtml::_('bootstrap.framework');
+$this->document->addScriptDeclaration("jQuery(function($){$('#tab-container a').click(function(e){e.preventDefault();$(this).tab('show');});});");
+
 ?>
 <div class="row-fluid">
 	<div class="filter-bar">
@@ -35,7 +39,7 @@ defined('_JEXEC') or die;
 <div class="row-fluid">
 	<div class="span12">
 
-		<ul class="nav nav-tabs">
+		<ul id="tab-container" class="nav nav-tabs">
 			<li>
 				<a href="#members" data-toggle="tab"><?php echo JText::_('COM_VOLUNTEERS_TAB_COORDINATORS') ?></a>
 			</li>

--- a/www/components/com_volunteers/views/team/tmpl/default.php
+++ b/www/components/com_volunteers/views/team/tmpl/default.php
@@ -9,7 +9,7 @@
 defined('_JEXEC') or die;
 
 JHtml::_('bootstrap.framework');
-$this->document->addScriptDeclaration("jQuery(function($){$('#tab-container a').click(function(e){e.preventDefault();$(this).tab('show');});});");
+$this->document->addScriptDeclaration("jQuery(function(\$){\$('#tab-container a').click(function(e){e.preventDefault();\$(this).tab('show');});});");
 
 ?>
 <div class="row-fluid">

--- a/www/components/com_volunteers/views/team/tmpl/default.php
+++ b/www/components/com_volunteers/views/team/tmpl/default.php
@@ -7,10 +7,6 @@
 
 // No direct access.
 defined('_JEXEC') or die;
-
-JHtml::_('bootstrap.framework');
-$this->document->addScriptDeclaration("jQuery(function(\$){\$('#tab-container a').click(function(e){e.preventDefault();\$(this).tab('show');});});");
-
 ?>
 <div class="row-fluid">
 	<div class="filter-bar">
@@ -455,15 +451,6 @@ $this->document->addScriptDeclaration("jQuery(function(\$){\$('#tab-container a'
 	if (url.match('#')) {
 		jQuery('.nav-tabs a[href="#' + url.split('#')[1] + '"]').tab('show');
 	}
-
-	// With HTML5 history API, we can easily prevent scrolling!
-	jQuery('.nav-tabs a').on('shown.bs.tab', function (e) {
-		if (history.pushState) {
-			history.pushState(null, null, e.target.hash);
-		} else {
-			window.location.hash = e.target.hash; //Polyfill for old browsers
-		}
-	});
 
 	jQuery('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
 		var target = this.href.split('#');

--- a/www/components/com_volunteers/views/team/tmpl/default.php
+++ b/www/components/com_volunteers/views/team/tmpl/default.php
@@ -7,6 +7,10 @@
 
 // No direct access.
 defined('_JEXEC') or die;
+
+JHtml::_('bootstrap.framework');
+$this->document->addScriptDeclaration("jQuery(function($){$('#tab-container a').click(function(e){e.preventDefault();$(this).tab('show');});});");
+
 ?>
 <div class="row-fluid">
 	<div class="filter-bar">
@@ -65,7 +69,7 @@ defined('_JEXEC') or die;
 <div class="row-fluid">
 	<div class="span12">
 
-		<ul class="nav nav-tabs">
+		<ul id="tab-container" class="nav nav-tabs">
 			<?php if ($this->item->active): ?>
 				<li>
 					<a href="#members" data-toggle="tab"><?php echo JText::_('COM_VOLUNTEERS_TAB_MEMBERS') ?></a>

--- a/www/components/com_volunteers/views/volunteer/tmpl/default.php
+++ b/www/components/com_volunteers/views/volunteer/tmpl/default.php
@@ -7,6 +7,10 @@
 
 // No direct access.
 defined('_JEXEC') or die;
+
+JHtml::_('bootstrap.framework');
+$this->document->addScriptDeclaration("jQuery(function($){$('#tab-container a').click(function(e){e.preventDefault();$(this).tab('show');});});");
+
 ?>
 <?php if ($this->item->new): ?>
 	<div class="alert alert-success">
@@ -49,7 +53,7 @@ defined('_JEXEC') or die;
 <div class="row-fluid">
 	<div class="span12">
 
-		<ul class="nav nav-tabs">
+		<ul id="tab-container" class="nav nav-tabs">
 			<?php if ($this->item->teams->active): ?>
 				<li>
 					<a href="#teams" data-toggle="tab"><?php echo JText::_('COM_VOLUNTEERS_TAB_TEAMSINVOLVED') ?></a>

--- a/www/components/com_volunteers/views/volunteer/tmpl/default.php
+++ b/www/components/com_volunteers/views/volunteer/tmpl/default.php
@@ -7,10 +7,6 @@
 
 // No direct access.
 defined('_JEXEC') or die;
-
-JHtml::_('bootstrap.framework');
-$this->document->addScriptDeclaration("jQuery(function(\$){\$('#tab-container a').click(function(e){e.preventDefault();\$(this).tab('show');});});");
-
 ?>
 <?php if ($this->item->new): ?>
 	<div class="alert alert-success">
@@ -259,15 +255,6 @@ $this->document->addScriptDeclaration("jQuery(function(\$){\$('#tab-container a'
 	if (url.match('#')) {
 		jQuery('.nav-tabs a[href="#' + url.split('#')[1] + '"]').tab('show');
 	}
-
-	// With HTML5 history API, we can easily prevent scrolling!
-	jQuery('.nav-tabs a').on('shown.bs.tab', function (e) {
-		if (history.pushState) {
-			history.pushState(null, null, e.target.hash);
-		} else {
-			window.location.hash = e.target.hash; //Polyfill for old browsers
-		}
-	});
 
 	jQuery('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
 		var target = this.href.split('#');

--- a/www/components/com_volunteers/views/volunteer/tmpl/default.php
+++ b/www/components/com_volunteers/views/volunteer/tmpl/default.php
@@ -9,7 +9,7 @@
 defined('_JEXEC') or die;
 
 JHtml::_('bootstrap.framework');
-$this->document->addScriptDeclaration("jQuery(function($){$('#tab-container a').click(function(e){e.preventDefault();$(this).tab('show');});});");
+$this->document->addScriptDeclaration("jQuery(function(\$){\$('#tab-container a').click(function(e){e.preventDefault();\$(this).tab('show');});});");
 
 ?>
 <?php if ($this->item->new): ?>


### PR DESCRIPTION
Initialize the Bootstrap tab script on pages using tabs, this prevents the selector getting added to URL on each click.

Unfortunately the JHtml helper is only designed to spit out script if you use it to build your entire tab container, so instead of being able to use it the required script is just inlined into the layouts.

I also opted for adding a unique ID to the container in the off chance a change ever happens where another tab set is used.
