### PR TITLE
Added contact active volunteers functionality to the backend

### DIFF
--- a/www/administrator/components/com_volunteers/controllers/contact.php
+++ b/www/administrator/components/com_volunteers/controllers/contact.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @package    Joomla! Volunteers
+ * @copyright  Copyright (C) 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// No direct access.
+defined('_JEXEC') or die;
+
+/**
+ * Contact controller class.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class VolunteersControllerContact extends JControllerForm
+{
+	/**
+	 * Send an email to all active volunteers
+	 *
+	 * @throws  Exception
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function send()
+	{
+		$app   = JFactory::getApplication();
+		$input = $app->input;
+
+		$canDo = JHelperContent::getActions('com_volunteers');
+
+		if (!$canDo->get('core.manage'))
+		{
+			throw new Exception('No access to mail sending', 403);
+		}
+
+		$mailData = $input->get('jform', array(), 'Array');
+
+		/** @var VolunteersModelContact $model */
+		$model = $this->getModel();
+
+		$volunteers = $model->getActiveVolunteers();
+
+		$mailer = JFactory::getMailer();
+
+		$from     = $app->get('mailfrom');
+		$fromName = $app->get('fromname');
+
+		$subject = trim($mailData['subject']);
+		$body    = trim($mailData['message']);
+
+		foreach ($volunteers as $volunteer)
+		{
+			if (empty($volunteer->email))
+			{
+				continue;
+			}
+
+			$email = $volunteer->email;
+
+			// This is faster than always recreating the mailer instance
+			$mailer->clearAllRecipients();
+
+			$success = $mailer->sendMail($from, $fromName, $email, $subject, $body);
+
+			if (!$success)
+			{
+				$app->enqueueMessage(JText::sprintf('COM_VOLUNTEERS_MESSAGE_SENDING_FAILED', $email), 'warning');
+			}
+		}
+
+		$this->setRedirect('index.php?option=com_volunteers&view=contact', JText::_('COM_VOLUNTEERS_MESSAGE_SEND_SUCCESS'));
+	}
+}

--- a/www/administrator/components/com_volunteers/models/contact.php
+++ b/www/administrator/components/com_volunteers/models/contact.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @package    Joomla! Volunteers
+ * @copyright  Copyright (C) 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// No direct access.
+defined('_JEXEC') or die;
+
+/**
+ * Contact model.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class VolunteersModelContact extends JModelAdmin
+{
+	/**
+	 * Abstract method for getting the form from the model.
+	 *
+	 * @param   array   $data     Data for the form.
+	 * @param   boolean $loadData True if the form is to load its own data (default case), false if not.
+	 *
+	 * @return  mixed  A JForm object on success, false on failure
+	 */
+	public function getForm($data = array(), $loadData = false)
+	{
+		// Get the form.
+		$form = $this->loadForm('com_volunteers.contact', 'contact', array('control' => 'jform'));
+
+		if (empty($form))
+		{
+			return false;
+		}
+
+		return $form;
+	}
+
+	/**
+	 * Get active volunteers
+	 *
+	 * @return  mixed
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getActiveVolunteers()
+	{
+		$query = $this->_db->getQuery(true);
+
+		$query
+			->select('DISTINCT u.id, u.name, u.email')
+			->from('#__users AS u')
+			->leftJoin('#__volunteers_volunteers AS v ON u.id = v.user_id')
+			->leftJoin('#__volunteers_members AS m ON v.id = m.volunteer')
+			->leftJoin('#__volunteers_teams AS t ON t.id = m.team')
+			->where('m.team IS NOT NULL')
+			->where('t.title IS NOT NULL')
+			->where('m.date_ended IS NULL')
+			->where('t.date_ended IS NULL');
+
+		$this->_db->setQuery($query);
+
+		return $this->_db->loadObjectList();
+	}
+}

--- a/www/administrator/components/com_volunteers/models/forms/contact.xml
+++ b/www/administrator/components/com_volunteers/models/forms/contact.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+    <fieldset name="message">
+        <field
+                name="subject"
+                type="text"
+                class="input-xxlarge input-large-text"
+                label="COM_VOLUNTEERS_FIELD_SUBJECT"
+                required="true"
+        />
+        <field
+                name="message"
+                type="textarea"
+                rows="6"
+                label="COM_VOLUNTEERS_FIELD_TEXT"
+                required="true"
+        />
+    </fieldset>
+</form>

--- a/www/administrator/components/com_volunteers/views/contact/tmpl/default.php
+++ b/www/administrator/components/com_volunteers/views/contact/tmpl/default.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @package    Joomla! Volunteers
+ * @copyright  Copyright (C) 2016 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// No direct access.
+defined('_JEXEC') or die;
+
+JHtml::addIncludePath(JPATH_COMPONENT . '/helpers/html');
+
+JHtml::_('behavior.formvalidator');
+
+JFactory::getDocument()->addScriptDeclaration("
+	Joomla.submitbutton = function (task) {
+		if (task == 'contact.cancel' || document.formvalidator.isValid(document.getElementById('adminForm'))) {
+			Joomla.submitform(task, document.getElementById('adminForm'));
+		}
+	}
+");
+?>
+
+<form action="<?php echo JRoute::_('index.php?option=com_volunteers&view=contact'); ?>"
+	  method="post" name="adminForm" id="adminForm" class="form-validate">
+
+	<?php echo $this->form->renderFieldset('message'); ?>
+
+	<input type="hidden" name="task" value=""/>
+	<?php echo JHtml::_('form.token'); ?>
+</form>

--- a/www/administrator/components/com_volunteers/views/contact/view.html.php
+++ b/www/administrator/components/com_volunteers/views/contact/view.html.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @package    Joomla! Volunteers
+ * @copyright  Copyright (C) 2017 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// No direct access.
+defined('_JEXEC') or die;
+
+/**
+ * View to contact active volunteers.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class VolunteersViewContact extends JViewLegacy
+{
+	protected $form;
+
+	/**
+	 * Display the view
+	 *
+	 * @param   string  $tpl  Template
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function display($tpl = null)
+	{
+		/** @var JForm form */
+		$this->form  = $this->get('Form');
+
+
+
+		// Check for errors.
+		if (count($errors = $this->get('Errors')))
+		{
+			JError::raiseError(500, implode("\n", $errors));
+
+			return false;
+		}
+
+		$this->addToolbar();
+		parent::display($tpl);
+	}
+
+	/**
+	 * Add the page title and toolbar.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function addToolbar()
+	{
+		JFactory::getApplication()->input->set('hidemainmenu', true);
+
+		$canDo = JHelperContent::getActions('com_volunteers');
+
+		// Set toolbar title
+		JToolbarHelper::title(JText::_('COM_VOLUNTEERS') . ': ' . JText::_('COM_VOLUNTEERS_CONTACT_ACTIVE_VOLUNTEERS'), 'joomla');
+
+		if ($canDo->get('core.manage'))
+		{
+			JToolbarHelper::custom('contact.send', 'mail', 'mail', 'COM_VOLUNTEERS_CONTACT', false);
+		}
+
+		JToolbarHelper::cancel('contact.cancel');
+	}
+}

--- a/www/administrator/language/en-GB/en-GB.com_volunteers.ini
+++ b/www/administrator/language/en-GB/en-GB.com_volunteers.ini
@@ -282,3 +282,10 @@ COM_VOLUNTEERS_HOME_INTRO_WHY_BUTTON="Get to know Joomlers!"
 ;Peakon
 COM_VOLUNTEERS_FIELD_PEAKON_INTRO="Please indicate below if you agree to your details being shared with Peakon. Peakon is a third party with whom the Joomla! Project is working as part of the Volunteer Engagement Program. Your Name, Email Address and Country will be shared with their system for the sole purpose of sending you surveys. data provided to Peakon through the surveys the Joomla! Project will send you is completely anonymous however. <a href="https://volunteers.joomla.org/peakon">More Information</a>"
 COM_VOLUNTEERS_FIELD_PEAKON="Enable Participation"
+
+;Contact
+COM_VOLUNTEERS_FIELD_SUBJECT="Email Subject"
+COM_VOLUNTEERS_FIELD_TEXT="Text (Non-Html)"
+COM_VOLUNTEERS_CONTACT="Contact"
+COM_VOLUNTEERS_MESSAGE_SENDING_FAILED="Sending the message to %s failed."
+COM_VOLUNTEERS_CONTACT_ACTIVE_VOLUNTEERS="Contact active Volunteers"


### PR DESCRIPTION
Adds a simple contact form to the Volunteers component in the backend for sending a non-html email to all active volunteers (which are in teams and not on the honor roll)