### PR TITLE
Drop Certification Profile link and frontend view

### DIFF
--- a/www/components/com_volunteers/views/registration/tmpl/default.php
+++ b/www/components/com_volunteers/views/registration/tmpl/default.php
@@ -86,7 +86,8 @@ JHtml::_('formbehavior.chosen', 'select');
 
 		<?php echo $this->form->renderField('joomlaforum'); ?>
 		<?php echo $this->form->renderField('joomladocs'); ?>
-		<?php echo $this->form->renderField('certification'); ?>
+		<?php // Disabled until there is a api we can check against ?>
+		<?php //echo $this->form->renderField('certification'); ?>
 
         <hr>
 

--- a/www/components/com_volunteers/views/volunteer/tmpl/default.php
+++ b/www/components/com_volunteers/views/volunteer/tmpl/default.php
@@ -23,14 +23,6 @@ defined('_JEXEC') or die;
 <div class="row-fluid profile">
     <div class="span3 volunteer-image">
 		<?php echo VolunteersHelper::image($this->item->image, 'large', false, $this->item->name); ?>
-
-		<?php if ($this->item->certification): ?>
-            <div class="volunteer-certificated">
-                <a href="https://exam.joomla.org/directory/user/<?php echo($this->item->certification) ?>" target="_blank">
-                    <img src="https://exam.joomla.org/images/badge.png" class="img-responsive"/>
-                </a>
-            </div>
-		<?php endif; ?>
     </div>
     <div class="span9">
         <div class="filter-bar">

--- a/www/components/com_volunteers/views/volunteer/tmpl/edit.php
+++ b/www/components/com_volunteers/views/volunteer/tmpl/edit.php
@@ -134,7 +134,8 @@ JFactory::getDocument()->addScriptDeclaration("
 
 		<?php echo $this->form->renderField('joomlaforum'); ?>
 		<?php echo $this->form->renderField('joomladocs'); ?>
-		<?php echo $this->form->renderField('certification'); ?>
+		<?php // Disabled until there is a api we can check against ?>
+		<?php //echo $this->form->renderField('certification'); ?>
 
         <hr>
 


### PR DESCRIPTION
Drop Certification Profile link and frontend view until there is a propper API to validate that to not damage the Certification brand.

see: https://github.com/joomla/volunteers.joomla.org/issues/152