### PR TITLE
Make more efficient use of homepage space

### DIFF
--- a/www/components/com_volunteers/views/home/tmpl/default.php
+++ b/www/components/com_volunteers/views/home/tmpl/default.php
@@ -14,69 +14,65 @@ JFactory::getDocument()->addScript('media/com_volunteers/js/oms.js', 'text/javas
 ?>
 
 <div class="row-fluid">
-    <img style="width: 100%" src="/images/volunteer-header.png" alt="Become a Joomla! contributor">
-</div>
-
-<br>
-
-<div class="row-fluid">
-    <div class="span6">
-        <h2><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_HOW_TITLE'); ?></h2>
-        <p><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_HOW_DESC'); ?></p>
-        <p><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_HOW_ACTION'); ?></p>
-        <p>
-            <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=roles'); ?>" class="btn"><span class="icon-chevron-right"></span><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_HOW_BUTTON'); ?>
-            </a>
-        </p>
-    </div>
-    <div class="span6">
-        <h2><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_WHY_TITLE'); ?></h2>
-        <p><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_WHY_DESC'); ?></p>
-        <p><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_WHY_ACTION'); ?></p>
-        <p>
-            <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteers'); ?>" class="btn"><span class="icon-chevron-right"></span><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_WHY_BUTTON'); ?>
-            </a>
-        </p>
-    </div>
-</div>
-
-<br>
-
-<div class="row-fluid">
-    <div class="span8">
-        <h2><?php echo JText::_('COM_VOLUNTEERS_LATEST_REPORTS') ?></h2>
-		<?php if (!empty($this->reports)) foreach ($this->reports as $i => $item): ?>
-            <div class="row-fluid report">
-                <div class="span2">
-                    <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteer&id=' . $item->volunteer_id) ?>">
-						<?php echo VolunteersHelper::image($item->volunteer_image, 'large', false, $item->volunteer_name); ?>
-                    </a>
-                </div>
-                <div class="span10">
-                    <h3 class="report-title">
-                        <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=report&id=' . $item->id) ?>">
-							<?php echo($item->title); ?>
-                        </a>
-                    </h3>
-                    <p class="muted">
-						<?php echo JText::_('COM_VOLUNTEERS_BY') ?>
-                        <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteer&id=' . $item->volunteer_id) ?>"><?php echo $item->volunteer_name; ?></a>
-						<?php echo JText::_('COM_VOLUNTEERS_ON') ?> <?php echo VolunteersHelper::date($item->created, 'Y-m-d H:i'); ?>
-						<?php echo JText::_('COM_VOLUNTEERS_IN') ?>
-                        <a href="<?php echo $item->link; ?>"><?php echo $item->name; ?></a>
-                    </p>
-                    <p><?php echo JHtml::_('string.truncate', strip_tags(trim($item->description)), 380); ?></p>
-                    <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=report&id=' . $item->id) ?>" class="btn">
-                        <span class="icon-chevron-right"></span><?php echo JText::_('COM_VOLUNTEERS_READ_MORE') ?>&nbsp;<?php echo JHtml::_('string.truncate', $item->title, 55); ?>
-                    </a>
-                </div>
+    <div class="span9">
+        <div class="row-fluid">
+            <img style="width: 100%" src="/images/volunteer-header.png" alt="Become a Joomla! contributor">
+        </div>
+        <div class="row-fluid">
+            <div class="span6">
+                <h2><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_HOW_TITLE'); ?></h2>
+                <p><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_HOW_DESC'); ?></p>
+                <p><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_HOW_ACTION'); ?></p>
+                <p>
+                    <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=roles'); ?>" class="btn"><span class="icon-chevron-right"></span><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_HOW_BUTTON'); ?></a>
+                </p>
             </div>
-            <hr>
-		<?php endforeach; ?>
-        <a class="btn btn-large btn-block" href="<?php echo JRoute::_('index.php?option=com_volunteers&view=reports'); ?>"><?php echo JText::_('COM_VOLUNTEERS_READ_MORE_REPORTS') ?></a>
+            <div class="span6">
+                <h2><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_WHY_TITLE'); ?></h2>
+                <p><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_WHY_DESC'); ?></p>
+                <p><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_WHY_ACTION'); ?></p>
+                <p>
+                    <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteers'); ?>" class="btn"><span class="icon-chevron-right"></span><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_WHY_BUTTON'); ?></a>
+                </p>
+            </div>
+        </div>
+        <div class="row-fluid">
+            <div class="span12">
+                <h2><?php echo JText::_('COM_VOLUNTEERS_LATEST_REPORTS') ?></h2>
+        		<?php if (!empty($this->reports)) foreach ($this->reports as $i => $item): ?>
+                    <div class="row-fluid report">
+                        <div class="span2">
+                            <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteer&id=' . $item->volunteer_id) ?>">
+        						<?php echo VolunteersHelper::image($item->volunteer_image, 'large', false, $item->volunteer_name); ?>
+                            </a>
+                        </div>
+                        <div class="span10">
+                            <h3 class="report-title">
+                                <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=report&id=' . $item->id) ?>">
+        							<?php echo($item->title); ?>
+                                </a>
+                            </h3>
+                            <p class="muted">
+        						<?php echo JText::_('COM_VOLUNTEERS_BY') ?>
+                                <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteer&id=' . $item->volunteer_id) ?>"><?php echo $item->volunteer_name; ?></a>
+        						<?php echo JText::_('COM_VOLUNTEERS_ON') ?> <?php echo VolunteersHelper::date($item->created, 'Y-m-d H:i'); ?>
+        						<?php echo JText::_('COM_VOLUNTEERS_IN') ?>
+                                <a href="<?php echo $item->link; ?>"><?php echo $item->name; ?></a>
+                            </p>
+                            <p><?php echo JHtml::_('string.truncate', strip_tags(trim($item->description)), 380); ?></p>
+                            <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=report&id=' . $item->id) ?>" class="btn">
+                                <span class="icon-chevron-right"></span><?php echo JText::_('COM_VOLUNTEERS_READ_MORE') ?>&nbsp;<?php echo JHtml::_('string.truncate', $item->title, 55); ?>
+                            </a>
+                        </div>
+                    </div>
+                    <hr>
+        		<?php endforeach; ?>
+                <a class="btn btn-large btn-block" href="<?php echo JRoute::_('index.php?option=com_volunteers&view=reports'); ?>"><?php echo JText::_('COM_VOLUNTEERS_READ_MORE_REPORTS') ?></a>
+            </div>
+        </div>
     </div>
-
-    <div class="span4">
+    <div class="span3">
+		<?php echo JHtml::_('content.prepare', '{loadmodule Login Form}'); ?>
         <div class="well joomlastory">
             <h2><?php echo JText::_('COM_VOLUNTEERS_JOOMLASTORY') ?></h2>
             <ul class="media-list">
@@ -103,32 +99,8 @@ JFactory::getDocument()->addScript('media/com_volunteers/js/oms.js', 'text/javas
                 </li>
             </ul>
         </div>
-
-        <h2><?php echo JText::_('COM_VOLUNTEERS_LATEST_VOLUNTEERS') ?></h2>
-		<?php if (!empty($this->volunteers)) foreach ($this->volunteers as $i => $item): ?>
-            <ul class="media-list latest-volunteers">
-                <li class="media">
-                    <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteer&id=' . $item->id) ?>">
-						<span class="pull-left">
-							<?php echo VolunteersHelper::image($item->image, 'small', false, $item->name); ?>
-						</span>
-                        <div class="media-body">
-                            <h3 class="media-heading">
-								<?php echo $item->name; ?>
-                            </h3>
-                            <p class="muted">
-                                <span class="icon-location"></span> <?php echo VolunteersHelper::location($item->country, $item->city); ?>
-                            </p>
-                        </div>
-                    </a>
-                </li>
-            </ul>
-		<?php endforeach; ?>
-        <a class="btn btn-large btn-block" href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteers'); ?>"><?php echo JText::_('COM_VOLUNTEERS_READ_MORE_VOLUNTEERS') ?></a>
     </div>
 </div>
-
-<br>
 
 <div class="row-fluid">
     <div class="span12">

--- a/www/components/com_volunteers/views/home/tmpl/default.php
+++ b/www/components/com_volunteers/views/home/tmpl/default.php
@@ -14,72 +14,67 @@ JFactory::getDocument()->addScript('media/com_volunteers/js/oms.js', 'text/javas
 ?>
 
 <div class="row-fluid">
-    <div class="span12">
-        <div class="row-fluid">
-            <img style="width: 100%" src="/images/volunteer-header.png" alt="Become a Joomla! contributor">
-        </div>
-        <div class="row-fluid">
-            <div class="span6">
-                <h2><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_HOW_TITLE'); ?></h2>
-                <p><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_HOW_DESC'); ?></p>
-                <p><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_HOW_ACTION'); ?></p>
-                <p>
-                    <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=roles'); ?>" class="btn"><span class="icon-chevron-right"></span><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_HOW_BUTTON'); ?></a>
-                </p>
-            </div>
-            <div class="span6">
-                <h2><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_WHY_TITLE'); ?></h2>
-                <p><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_WHY_DESC'); ?></p>
-                <p><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_WHY_ACTION'); ?></p>
-                <p>
-                    <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteers'); ?>" class="btn"><span class="icon-chevron-right"></span><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_WHY_BUTTON'); ?></a>
-                </p>
-            </div>
-        </div>
-        <div class="row-fluid">
-            <div class="span12">
-                <h2><?php echo JText::_('COM_VOLUNTEERS_LATEST_REPORTS') ?></h2>
-        		<?php if (!empty($this->reports)) foreach ($this->reports as $i => $item): ?>
-                    <div class="row-fluid report">
-                        <div class="span2">
-                            <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteer&id=' . $item->volunteer_id) ?>">
-        						<?php echo VolunteersHelper::image($item->volunteer_image, 'large', false, $item->volunteer_name); ?>
-                            </a>
-                        </div>
-                        <div class="span10">
-                            <h3 class="report-title">
-                                <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=report&id=' . $item->id) ?>">
-        							<?php echo($item->title); ?>
-                                </a>
-                            </h3>
-                            <p class="muted">
-        						<?php echo JText::_('COM_VOLUNTEERS_BY') ?>
-                                <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteer&id=' . $item->volunteer_id) ?>"><?php echo $item->volunteer_name; ?></a>
-        						<?php echo JText::_('COM_VOLUNTEERS_ON') ?> <?php echo VolunteersHelper::date($item->created, 'Y-m-d H:i'); ?>
-        						<?php echo JText::_('COM_VOLUNTEERS_IN') ?>
-                                <a href="<?php echo $item->link; ?>"><?php echo $item->name; ?></a>
-                            </p>
-                            <p><?php echo JHtml::_('string.truncate', strip_tags(trim($item->description)), 380); ?></p>
-                            <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=report&id=' . $item->id) ?>" class="btn">
-                                <span class="icon-chevron-right"></span><?php echo JText::_('COM_VOLUNTEERS_READ_MORE') ?>&nbsp;<?php echo JHtml::_('string.truncate', $item->title, 55); ?>
-                            </a>
-                        </div>
-                    </div>
-                    <hr>
-        		<?php endforeach; ?>
-                <a class="btn btn-large btn-block" href="<?php echo JRoute::_('index.php?option=com_volunteers&view=reports'); ?>"><?php echo JText::_('COM_VOLUNTEERS_READ_MORE_REPORTS') ?></a>
-            </div>
-        </div>
-    </div>
+    <img style="width: 100%" src="/images/volunteer-header.png" alt="Become a Joomla! contributor">
 </div>
-
+<br>
 <div class="row-fluid">
-    <div class="span12">
-        <h2><?php echo count($this->markers) . ' ' . JText::_('COM_VOLUNTEERS_VOLUNTEERS_WORLD') ?></h2>
-        <div id="map-canvas"></div>
+    <div class="span6">
+        <h2><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_HOW_TITLE'); ?></h2>
+        <p><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_HOW_DESC'); ?></p>
+        <p><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_HOW_ACTION'); ?></p>
+        <p>
+            <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=roles'); ?>" class="btn"><span class="icon-chevron-right"></span><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_HOW_BUTTON'); ?>
+            </a>
+        </p>
+    </div>
+    <div class="span6">
+        <h2><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_WHY_TITLE'); ?></h2>
+        <p><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_WHY_DESC'); ?></p>
+        <p><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_WHY_ACTION'); ?></p>
+        <p>
+            <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteers'); ?>" class="btn"><span class="icon-chevron-right"></span><?php echo JText::_('COM_VOLUNTEERS_HOME_INTRO_WHY_BUTTON'); ?>
+            </a>
+        </p>
     </div>
 </div>
-
+<br>
+<div class="row-fluid">
+    <h2><?php echo JText::_('COM_VOLUNTEERS_LATEST_REPORTS') ?></h2>
+	<?php if (!empty($this->reports)) foreach ($this->reports as $i => $item): ?>
+        <div class="row-fluid report">
+            <div class="span2">
+                <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteer&id=' . $item->volunteer_id) ?>">
+					<?php echo VolunteersHelper::image($item->volunteer_image, 'large', false, $item->volunteer_name); ?>
+                </a>
+            </div>
+            <div class="span10">
+                <h3 class="report-title">
+                    <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=report&id=' . $item->id) ?>">
+						<?php echo($item->title); ?>
+                    </a>
+                </h3>
+                <p class="muted">
+					<?php echo JText::_('COM_VOLUNTEERS_BY') ?>
+                    <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteer&id=' . $item->volunteer_id) ?>"><?php echo $item->volunteer_name; ?></a>
+					<?php echo JText::_('COM_VOLUNTEERS_ON') ?> <?php echo VolunteersHelper::date($item->created, 'Y-m-d H:i'); ?>
+					<?php echo JText::_('COM_VOLUNTEERS_IN') ?>
+                    <a href="<?php echo $item->link; ?>"><?php echo $item->name; ?></a>
+                </p>
+                <p><?php echo JHtml::_('string.truncate', strip_tags(trim($item->description)), 380); ?></p>
+                <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=report&id=' . $item->id) ?>" class="btn">
+                    <span class="icon-chevron-right"></span><?php echo JText::_('COM_VOLUNTEERS_READ_MORE') ?>&nbsp;<?php echo JHtml::_('string.truncate', $item->title, 55); ?>
+                </a>
+            </div>
+        </div>
+        <hr>
+	<?php endforeach; ?>
+    <a class="btn btn-large btn-block" href="<?php echo JRoute::_('index.php?option=com_volunteers&view=reports'); ?>"><?php echo JText::_('COM_VOLUNTEERS_READ_MORE_REPORTS') ?></a>
+</div>
+<br>
+<div class="row-fluid">
+    <h2><?php echo count($this->markers) . ' ' . JText::_('COM_VOLUNTEERS_VOLUNTEERS_WORLD') ?></h2>
+    <div id="map-canvas"></div>
+</div>
 <script>
     function initialise() {
         var mapOptions = {

--- a/www/components/com_volunteers/views/home/tmpl/default.php
+++ b/www/components/com_volunteers/views/home/tmpl/default.php
@@ -14,7 +14,7 @@ JFactory::getDocument()->addScript('media/com_volunteers/js/oms.js', 'text/javas
 ?>
 
 <div class="row-fluid">
-    <div class="span9">
+    <div class="span12">
         <div class="row-fluid">
             <img style="width: 100%" src="/images/volunteer-header.png" alt="Become a Joomla! contributor">
         </div>
@@ -70,57 +70,6 @@ JFactory::getDocument()->addScript('media/com_volunteers/js/oms.js', 'text/javas
                 <a class="btn btn-large btn-block" href="<?php echo JRoute::_('index.php?option=com_volunteers&view=reports'); ?>"><?php echo JText::_('COM_VOLUNTEERS_READ_MORE_REPORTS') ?></a>
             </div>
         </div>
-    </div>
-    <div class="span3">
-		<?php echo JHtml::_('content.prepare', '{loadmodule Login Form}'); ?>
-        <div class="well joomlastory">
-            <h2><?php echo JText::_('COM_VOLUNTEERS_JOOMLASTORY') ?></h2>
-            <ul class="media-list">
-                <li class="media">
-                    <a class="pull-left" href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteer&id=' . $this->volunteerstory->id) ?>">
-						<?php echo VolunteersHelper::image($this->volunteerstory->image, 'small', false, $this->volunteerstory->name); ?>
-                    </a>
-                    <div class="media-body">
-                        <h3 class="media-heading">
-                            <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteer&id=' . $this->volunteerstory->id) ?>">
-								<?php echo $this->volunteerstory->name; ?>
-                            </a>
-                        </h3>
-                        <p class="muted">
-                            <span class="icon-location"></span> <?php echo VolunteersHelper::location($this->volunteerstory->country, $this->volunteerstory->city); ?>
-                        </p>
-                    </div>
-                </li>
-                <li class="media">
-                    <p><?php echo JHtml::_('string.truncate', strip_tags(trim($this->volunteerstory->joomlastory)), 500); ?></p>
-                    <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteer&id=' . $this->volunteerstory->id) ?>#joomlastory" class="btn">
-                        <span class="icon-chevron-right"></span><?php echo JText::_('COM_VOLUNTEERS_READ_MORE_JOOMLASTORY') ?>
-                    </a>
-                </li>
-            </ul>
-        </div>
-        
-        <h2><?php echo JText::_('COM_VOLUNTEERS_LATEST_VOLUNTEERS') ?></h2>
-	    <?php if (!empty($this->volunteers)) foreach ($this->volunteers as $i => $item): ?>
-            <ul class="media-list latest-volunteers">
-                <li class="media">
-                    <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteer&id=' . $item->id) ?>">
-						<span class="pull-left">
-							<?php echo VolunteersHelper::image($item->image, 'small', false, $item->name); ?>
-						</span>
-                        <div class="media-body">
-                            <h3 class="media-heading">
-							    <?php echo $item->name; ?>
-                            </h3>
-                            <p class="muted">
-                                <span class="icon-location"></span> <?php echo VolunteersHelper::location($item->country, $item->city); ?>
-                            </p>
-                        </div>
-                    </a>
-                </li>
-            </ul>
-	    <?php endforeach; ?>
-        <a class="btn btn-large btn-block" href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteers'); ?>"><?php echo JText::_('COM_VOLUNTEERS_READ_MORE_VOLUNTEERS') ?></a>
     </div>
 </div>
 

--- a/www/components/com_volunteers/views/home/tmpl/default.php
+++ b/www/components/com_volunteers/views/home/tmpl/default.php
@@ -99,6 +99,28 @@ JFactory::getDocument()->addScript('media/com_volunteers/js/oms.js', 'text/javas
                 </li>
             </ul>
         </div>
+        
+        <h2><?php echo JText::_('COM_VOLUNTEERS_LATEST_VOLUNTEERS') ?></h2>
+	    <?php if (!empty($this->volunteers)) foreach ($this->volunteers as $i => $item): ?>
+            <ul class="media-list latest-volunteers">
+                <li class="media">
+                    <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteer&id=' . $item->id) ?>">
+						<span class="pull-left">
+							<?php echo VolunteersHelper::image($item->image, 'small', false, $item->name); ?>
+						</span>
+                        <div class="media-body">
+                            <h3 class="media-heading">
+							    <?php echo $item->name; ?>
+                            </h3>
+                            <p class="muted">
+                                <span class="icon-location"></span> <?php echo VolunteersHelper::location($item->country, $item->city); ?>
+                            </p>
+                        </div>
+                    </a>
+                </li>
+            </ul>
+	    <?php endforeach; ?>
+        <a class="btn btn-large btn-block" href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteers'); ?>"><?php echo JText::_('COM_VOLUNTEERS_READ_MORE_VOLUNTEERS') ?></a>
     </div>
 </div>
 

--- a/www/components/com_volunteers/views/home/view.html.php
+++ b/www/components/com_volunteers/views/home/view.html.php
@@ -26,9 +26,7 @@ class VolunteersViewHome extends JViewLegacy
 	 */
 	public function display($tpl = null)
 	{
-		$this->volunteers     = $this->get('LatestVolunteers');
 		$this->reports        = $this->get('LatestReports');
-		$this->volunteerstory = $this->get('VolunteerStory');
 		$this->markers        = $this->get('MapMarkers');
 
 		// Check for errors.

--- a/www/modules/mod_volunteers_latest/mod_volunteers_latest.php
+++ b/www/modules/mod_volunteers_latest/mod_volunteers_latest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @package    Joomla! Volunteers
+ * @copyright  Copyright (C) 2018 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// No direct access.
+defined('_JEXEC') or die;
+
+// Get reports
+$model = JModelLegacy::getInstance('Volunteers', 'VolunteersModel', array('ignore_request' => true));
+$model->setState('list.limit', 5);
+$model->setState('list.ordering', 'a.created');
+$model->setState('list.direction', 'desc');
+$model->setState('filter.image', 1);
+
+$volunteers = $model->getItems();
+
+require JModuleHelper::getLayoutPath('mod_volunteers_latest', 'default');

--- a/www/modules/mod_volunteers_latest/mod_volunteers_latest.xml
+++ b/www/modules/mod_volunteers_latest/mod_volunteers_latest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="module" version="3.1" client="site" method="upgrade">
+    <name>mod_volunteers_latest</name>
+    <author>Joomla! Project</author>
+    <creationDate>February 2018</creationDate>
+    <copyright>Copyright (C) 2005 - 2018 Open Source Matters. All rights reserved.</copyright>
+    <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+    <authorEmail>admin@joomla.org</authorEmail>
+    <authorUrl>www.joomla.org</authorUrl>
+    <version>1.0.0</version>
+    <description>Volunteers - Latest Joomlers</description>
+
+    <files>
+        <filename module="mod_volunteers_latest">mod_volunteers_latest.php</filename>
+        <folder>tmpl</folder>
+    </files>
+</extension>

--- a/www/modules/mod_volunteers_latest/tmpl/default.php
+++ b/www/modules/mod_volunteers_latest/tmpl/default.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @package    Joomla! Volunteers
+ * @copyright  Copyright (C) 2018 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// No direct access.
+defined('_JEXEC') or die;
+?>
+
+<?php if (!empty($volunteers)) foreach ($volunteers as $i => $item): ?>
+    <ul class="media-list latest-volunteers">
+        <li class="media">
+            <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteer&id=' . $item->id) ?>">
+						<span class="pull-left">
+							<?php echo VolunteersHelper::image($item->image, 'small', false, $item->name); ?>
+						</span>
+                <div class="media-body">
+                    <h3 class="media-heading">
+						<?php echo $item->name; ?>
+                    </h3>
+                    <p class="muted">
+                        <span class="icon-location"></span> <?php echo VolunteersHelper::location($item->country, $item->city); ?>
+                    </p>
+                </div>
+            </a>
+        </li>
+    </ul>
+<?php endforeach; ?>
+<a class="btn btn-large btn-block" href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteers'); ?>"><?php echo JText::_('COM_VOLUNTEERS_READ_MORE_VOLUNTEERS') ?></a>

--- a/www/modules/mod_volunteers_story/mod_volunteers_story.php
+++ b/www/modules/mod_volunteers_story/mod_volunteers_story.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @package    Joomla! Volunteers
+ * @copyright  Copyright (C) 2018 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// No direct access.
+defined('_JEXEC') or die;
+
+$model = JModelLegacy::getInstance('Volunteers', 'VolunteersModel', array('ignore_request' => true));
+$model->setState('list.limit', 1);
+$model->setState('list.ordering', 'rand()');
+$model->setState('filter.image', 1);
+$model->setState('filter.joomlastory', 1);
+
+$items = $model->getItems();
+
+$story = $items[0];
+
+require JModuleHelper::getLayoutPath('mod_volunteers_story', 'default');

--- a/www/modules/mod_volunteers_story/mod_volunteers_story.xml
+++ b/www/modules/mod_volunteers_story/mod_volunteers_story.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="module" version="3.1" client="site" method="upgrade">
+    <name>mod_volunteers_story</name>
+    <author>Joomla! Project</author>
+    <creationDate>February 2018</creationDate>
+    <copyright>Copyright (C) 2005 - 2018 Open Source Matters. All rights reserved.</copyright>
+    <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+    <authorEmail>admin@joomla.org</authorEmail>
+    <authorUrl>www.joomla.org</authorUrl>
+    <version>1.0.0</version>
+    <description>Volunteers - Joomler Story</description>
+
+    <files>
+        <filename module="mod_volunteers_story">mod_volunteers_story.php</filename>
+        <folder>tmpl</folder>
+    </files>
+</extension>

--- a/www/modules/mod_volunteers_story/tmpl/default.php
+++ b/www/modules/mod_volunteers_story/tmpl/default.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @package    Joomla! Volunteers
+ * @copyright  Copyright (C) 2018 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// No direct access.
+defined('_JEXEC') or die;
+?>
+
+<ul class="media-list">
+    <li class="media">
+        <a class="pull-left" href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteer&id=' . $story->id) ?>">
+			<?php echo VolunteersHelper::image($story->image, 'small', false, $story->name); ?>
+        </a>
+        <div class="media-body">
+            <h3 class="media-heading">
+                <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteer&id=' . $story->id) ?>">
+					<?php echo $story->name; ?>
+                </a>
+            </h3>
+            <p class="muted">
+                <span class="icon-location"></span> <?php echo VolunteersHelper::location($story->country, $story->city); ?>
+            </p>
+        </div>
+    </li>
+    <li class="media">
+        <p><?php echo JHtml::_('string.truncate', strip_tags(trim($story->joomlastory)), 500); ?></p>
+        <a href="<?php echo JRoute::_('index.php?option=com_volunteers&view=volunteer&id=' . $story->id) ?>#joomlastory" class="btn">
+            <span class="icon-chevron-right"></span><?php echo JText::_('COM_VOLUNTEERS_READ_MORE_JOOMLASTORY') ?>
+        </a>
+    </li>
+</ul>


### PR DESCRIPTION
Having the module sidebar results in a lot of dead space on the homepage, IMO it's a bit uglier here than on inner content pages.  Instead of using the template position to render the sidebar, we can instead inline the module position into the homepage layout and make use of the full page, and that's what this PR aims to do.

### Changes

- Inlines the login form module position (`loadmodule` syntax should be validated against what is actually in the database, I referenced the SQL dump here in the repo to get a name)
- Moves the story and new Joomlers blocks into the sidebar space
- Makes the reports block go full width in the left column
- Makes the Google map go full width as its own grid row underneath the 9/3 split row

### Deployment Changes Required

- Unassign the login form from the homepage menu item

<img width="808" alt="screen shot 2018-02-11 at 12 45 40 pm" src="https://user-images.githubusercontent.com/368545/36076972-8ea6fb16-0f29-11e8-8772-4362fb33037b.png">
