### PR TITLE
Resolve pingdom related errors on identity.jorg

### DIFF
--- a/www/templates/joomla/helpers/template.php
+++ b/www/templates/joomla/helpers/template.php
@@ -366,7 +366,7 @@ class JoomlaTemplateHelper
 						'fbId'      => 'undefined',
 						'addthis'   => 'false',
 						'addthisId' => 'undefined',
-						'pingdomId' => '59300ad15992c776ad970068'
+						'pingdomId' => 'undefined'
 					],
 					'cookies'  => (object) [
 						'performance' => 'true',


### PR DESCRIPTION
For `line 31: getSiteConfig('identity.joomla.org')` the `'pingdom'` value has been changed to `undefined` in order to resolve any console related issues, that are produced from pingdom to identity.jorg.