### PR TITLE
Updated identity.joomla.org AddThis scripts

### DIFF
--- a/www/templates/joomla/helpers/template.php
+++ b/www/templates/joomla/helpers/template.php
@@ -362,16 +362,16 @@ class JoomlaTemplateHelper
 					'scripts'  => (object) [
 						'uaId'      => 'undefined',
 						'awId'      => 'undefined',
-						'twitter'   => 'false',
+						'twitter'   => 'undefined',
 						'fbId'      => 'undefined',
 						'addthis'   => 'true',
 						'addthisId' => 'ra-5d944d91cdb6c3f1',
-						'pingdomId' => '59300ad15992c776ad970068'
+						'pingdomId' => 'undefined'
 					],
 					'cookies'  => (object) [
 						'performance' => 'true',
 						'functional'  => 'true',
-						'advertising' => 'false'
+						'advertising' => 'true'
 					],
 					'issueUrl' => 'https://github.com/joomla/identity.joomla.org/issues/new?body=Please%20describe%20the%20problem%20or%20your%20issue'
 				];

--- a/www/templates/joomla/helpers/template.php
+++ b/www/templates/joomla/helpers/template.php
@@ -364,8 +364,8 @@ class JoomlaTemplateHelper
 						'awId'      => 'undefined',
 						'twitter'   => 'false',
 						'fbId'      => 'undefined',
-						'addthis'   => 'false',
-						'addthisId' => 'undefined',
+						'addthis'   => 'true',
+						'addthisId' => 'ra-5d944d91cdb6c3f1',
 						'pingdomId' => '59300ad15992c776ad970068'
 					],
 					'cookies'  => (object) [


### PR DESCRIPTION
Despite the creation of the AddThis script on identity.joomla.org, we still got issues on the property itself. 

The cookiescript, is validating the `$siteConfig->scripts->addthis->false` value as `true`, because the if statement checks for `!== 'undefined'` values. Therefore, the addthis script is appended to body with false values.

This commit, sets the  `$siteConfig->scripts->addthis = true` and the `$siteConfig->scripts->addthisId = <addthis id>`