### PR TITLE
Add Google Analytics ID for testing purposes

### DIFF
--- a/www/templates/joomla/helpers/template.php
+++ b/www/templates/joomla/helpers/template.php
@@ -381,7 +381,7 @@ class JoomlaTemplateHelper
 				$siteConfig = (object) [
 					'gtmId'    => 'GTM-5BL9XHS',
 					'scripts'  => (object) [
-						'uaId'      => 'undefined',
+						'uaId'      => 'UA-157297508-1',
 						'awId'      => 'undefined',
 						'twitter'   => 'undefined',
 						'fbSdk'     => 'undefined',


### PR DESCRIPTION
In order to finalize and fix any issues generated from GA cookies, we have created a temporary UA-ID for identity.jorg which should be removed after our tests and be unbind from the property.